### PR TITLE
introduce transcode._ObjectReference; improve serialized data readability

### DIFF
--- a/src/pypg/traits/config.py
+++ b/src/pypg/traits/config.py
@@ -6,7 +6,7 @@ from pypg.property_transcoder import PropertyClassEncoder
 class ConfigEncoder(PropertyClassEncoder):
     def _encode(self, obj: PropertyClass):
         return {
-            p.name: Encoder(p.get(obj), self, self.overrides).obj_id
+            p.name: Encoder(p.get(obj), self, self.overrides).obj_data
             for p in filter(Config.has_config_data, type(obj).properties)
         }
 

--- a/tests/test_type_schema_encoding.py
+++ b/tests/test_type_schema_encoding.py
@@ -1,62 +1,21 @@
+from pprint import pprint
 from unittest import TestCase
 
-from pypg import decode, encode
-from pypg.transcode import unpack
+from pypg import Property, decode, encode
 from tests.test_property import Example
+
+
+class ComplexExample(Example):
+    ex = Property[Example]()
+    ex2 = Property[Example]()
 
 
 class TypeSchemaEncodingTest(TestCase):
     def test_property_type_encoding(self):
-        enc = encode(Example)
-        ex_a_enc = encode(Example.a)
-        self.assertEqual(enc[ex_a_enc["root"]], ex_a_enc[ex_a_enc["root"]])
-        for t in Example.d.traits:
-            self.assertIn(str(id(t)), enc)
-        from pprint import pprint
-
+        enc = encode(ComplexExample)
         pprint(enc)
 
     def test_type_transcoding(self):
         enc = encode(int)
-        intid = str(id(int))
-        expected = {"root": intid, intid: ["type", str(int.__name__)]}
-        self.assertEqual(expected, enc)
+        self.assertEqual(['type', 'int'], enc)
         self.assertIs(int, decode(enc))
-
-    def test_unpack_schema(self):
-        actual = unpack(encode(Example))
-        expected = [
-            "tests.test_property.Example",
-            {
-                "a": [
-                    "pypg.property.Property",
-                    {"value_type": ["type", "float"], "traits": []},
-                ],
-                "a2": [
-                    "pypg.property.Property",
-                    {"value_type": ["type", "float"], "traits": []},
-                ],
-                "b": [
-                    "pypg.property.Property",
-                    {"value_type": ["type", "float"], "traits": []},
-                ],
-                "c": [
-                    "pypg.property.Property",
-                    {"value_type": ["type", "int"], "traits": []},
-                ],
-                "d": [
-                    "pypg.property.Property",
-                    {
-                        "value_type": ["type", "float"],
-                        "traits": [
-                            ["pypg.traits.unit.Unit", {"value": ["str", "mm"]}],
-                            [
-                                "pypg.traits.observable.Observable",
-                                "['pypg.property.PostSet']",
-                            ],
-                        ],
-                    },
-                ],
-            },
-        ]
-        self.assertEqual(expected, actual)


### PR DESCRIPTION
substantial rework to improve readability of serialized data; given an object defined like so: 

```python
class Example(PropertyClass):
    def default_poly(self, offset):
        return self.b * self.c + offset

    a = Property[float](default=MethodReference(default_poly, offset=1))
    a2 = Property[float](default=MethodReference(default_poly, offset=2))

    @classmethod
    def default_gain(cls):
        return 1

    b = Property[float](default=MethodReference(default_gain))

    @classmethod
    def _optional_c_traits(cls):
        pass

    c = Property[int](default=1, traits=_optional_c_traits)

    def default_sum(self):
        return self.a + self.b + self.c

    @classmethod
    def _d_traits(cls):
        return Unit("mm"), Observable[PostSet]()

    d = Property[float](
        default=1, getter=MethodReference(default_sum), traits=_d_traits
    )
# ...

class ComplexExample(Example):
    ex = Property[Example]()
    ex2 = Property[Example]()
```

https://github.com/mattefowler/pypg/blob/improve_serialized_readability/tests/test_property.py
https://github.com/mattefowler/pypg/blob/improve_serialized_readability/tests/test_type_schema_encoding.py

and instantiated thus:

```python
from tests.test_type_schema_encoding import ComplexExample, Example
from pypg import encode
from pprint import pprint
ce = ComplexExample(ex=(e:=Example()), ex2=e)
pprint(encode(ce))
```

encoding will now produce output as follows:

```python
['tests.test_type_schema_encoding.ComplexExample',
 ({'a': ['int', 2],
   'a2': ['int', 3],
   'b': ['int', 1],
   'c': ['int', 1],
   'd': ['int', 4],
   'ex': ['tests.test_property.Example',
          ({'a': ['int', 2],
            'a2': ['int', 3],
            'b': ['int', 1],
            'c': ['int', 1],
            'd': ['int', 4]},
           4342911376)],
   'ex2': ['pypg.transcode._ObjectReference', (4342911376, 4342914256)]},
  4315648848)]
```